### PR TITLE
feat: create feature for output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ license-file = "LICENSE"
 [[bin]]
 name = "variant_myth"
 path = "src/main.rs"
-
+required-features = ["cli"]
 
 [dependencies]
 # Specific
@@ -39,8 +39,10 @@ rayon          = { version = "1", optional = true }
 csv            = { version = "1" }
 niffler        = { version = "2", features = ["bzip2", "lzma", "gz", "bgz"] }
 noodles        = { version = "0.87", features = ["fasta"] }
-arrow          = { version = "54" }
-parquet        = { version = "54" }
+arrow          = { version = "54", optional = true }
+parquet        = { version = "54", optional = true }
+serde_json     = { version = "1", features = ["preserve_order"], optional = true }
+serde          = { version = "1", features = ["derive"], optional = true }
 
 # CLI management
 clap           = { version = "4", features = ["derive"], optional = true }
@@ -52,9 +54,6 @@ anyhow         = { version = "1" }
 # Logging and error management
 log            = { version = "0.4" }
 stderrlog      = { version = "0.5" }
-serde_json = { version = "1.0.135", features = ["preserve_order"] }
-serde = { version = "1.0.217", features = ["derive"] }
-
 
 [dev-dependencies]
 ## Benchmark management
@@ -67,10 +66,16 @@ tempfile       = { version = "3" }
 
 
 [features]
-default  = ["cli"]
-cli      = ["dep:clap"]
-parallel = ["dep:rayon", "clairiere/parallel"]
-bench    = []
+default     = ["cli", "out_parquet"]
+
+cli         = ["dep:clap"]
+parallel    = ["dep:rayon", "clairiere/parallel"]
+
+# output feature
+out_parquet = ["dep:arrow", "dep:parquet"]
+out_json    = ["dep:serde", "dep:serde_json"]
+
+bench       = []
 
 
 [profile.release]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -160,8 +160,10 @@ impl Command {
 #[derive(clap::Subcommand, std::fmt::Debug)]
 pub enum OutputSubCommand {
     /// Output are write in parquet format
+    #[cfg(feature = "out_parquet")]
     Parquet(Parquet),
     /// Output are write in json format
+    #[cfg(feature = "out_json")]
     Json(Json),
 }
 
@@ -169,7 +171,9 @@ impl OutputSubCommand {
     /// Create myth writer
     pub fn writer(&self) -> error::Result<Box<dyn output::MythWriter + std::marker::Send>> {
         match self {
+            #[cfg(feature = "out_parquet")]
             OutputSubCommand::Parquet(obj) => obj.writer(),
+            #[cfg(feature = "out_json")]
             OutputSubCommand::Json(obj) => obj.writer(),
         }
     }
@@ -177,6 +181,7 @@ impl OutputSubCommand {
 
 /// Output are write in parquet format
 #[derive(clap::Args, std::fmt::Debug)]
+#[cfg(feature = "out_parquet")]
 pub struct Parquet {
     /// Output path
     #[clap(short = 'p', long = "path")]
@@ -187,6 +192,7 @@ pub struct Parquet {
     block_size: Option<usize>,
 }
 
+#[cfg(feature = "out_parquet")]
 impl Parquet {
     /// Create myth writer
     pub fn writer(&self) -> error::Result<Box<dyn output::MythWriter + std::marker::Send>> {
@@ -205,6 +211,7 @@ impl Parquet {
 
 /// Output are write in json format
 #[derive(clap::Args, std::fmt::Debug)]
+#[cfg(feature = "out_json")]
 pub struct Json {
     /// Output path
     #[clap(short = 'p', long = "path")]
@@ -215,6 +222,7 @@ pub struct Json {
     json_format: Option<output::JsonFormat>,
 }
 
+#[cfg(feature = "out_json")]
 impl Json {
     /// Create myth writer
     pub fn writer(&self) -> error::Result<Box<dyn output::MythWriter + std::marker::Send>> {

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -7,7 +7,8 @@
 /* project use */
 
 /// Impact of variant
-#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "out_json", derive(serde::Serialize))]
 pub enum Impact {
     /// Variant have an High Impact
     High = 4,
@@ -94,7 +95,8 @@ impl From<&Effect> for Impact {
 }
 
 /// Effect of variant
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "out_json", derive(serde::Serialize))]
 pub enum Effect {
     /// A sequence variant whereby two genes, on alternate strands have become joined.
     BidirectionalGeneFusion,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod variant2myth;
 #[cfg(feature = "cli")]
 pub mod cli;
 
+#[cfg(feature = "out_json")]
 fn serialize_bstr<T, S>(v: T, serializer: S) -> Result<S::Ok, S::Error>
 where
     T: AsRef<[u8]>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 //! A variant annotater.
 
+#![cfg(feature = "cli")]
 #![warn(missing_docs)]
 
 /* std use */
 
 /* crate use */
-
 use anyhow::Context as _;
 use clap::Parser as _;
 

--- a/src/myth.rs
+++ b/src/myth.rs
@@ -9,23 +9,24 @@ use crate::effect;
 use crate::variant;
 
 /// Struct to store annotation information
-#[derive(Debug, derive_builder::Builder, Clone, PartialEq, serde::Serialize)]
+#[derive(Debug, derive_builder::Builder, Clone, PartialEq)]
+#[cfg_attr(feature = "out_json", derive(serde::Serialize))]
 #[builder(pattern = "owned")]
 pub struct AnnotationMyth {
     /// Source of annotation
-    #[serde(serialize_with = "crate::serialize_bstr")]
+    #[cfg_attr(feature = "out_json", serde(serialize_with = "crate::serialize_bstr"))]
     pub source: Vec<u8>,
 
     /// Feature type
-    #[serde(serialize_with = "crate::serialize_bstr")]
+    #[cfg_attr(feature = "out_json", serde(serialize_with = "crate::serialize_bstr"))]
     pub feature: Vec<u8>,
 
     /// Feature id
-    #[serde(serialize_with = "crate::serialize_bstr")]
+    #[cfg_attr(feature = "out_json", serde(serialize_with = "crate::serialize_bstr"))]
     pub id: Vec<u8>,
 
     #[builder(default)]
-    #[serde(serialize_with = "crate::serialize_bstr")]
+    #[cfg_attr(feature = "out_json", serde(serialize_with = "crate::serialize_bstr"))]
     /// Feature name
     pub name: Vec<u8>,
 
@@ -72,7 +73,8 @@ impl AnnotationMythBuilder {
 }
 
 /// Store information around variant
-#[derive(Debug, PartialEq, serde::Serialize)]
+#[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "out_json", derive(serde::Serialize))]
 pub struct Myth {
     /// Variant associate to Myth
     pub variant: variant::Variant,

--- a/src/output.rs
+++ b/src/output.rs
@@ -5,7 +5,9 @@
 /* crate use */
 
 /* module declaration */
+#[cfg(feature = "out_json")]
 mod json;
+#[cfg(feature = "out_parquet")]
 mod parquet;
 
 /* project use */
@@ -13,8 +15,11 @@ use crate::error;
 use crate::myth;
 
 /* reexport */
+#[cfg(feature = "out_json")]
 pub use json::JsonFormat;
+#[cfg(feature = "out_json")]
 pub use json::JsonWriter;
+#[cfg(feature = "out_parquet")]
 pub use parquet::ParquetWriter;
 
 /// Common metadata to all output

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -7,22 +7,23 @@
 /* project use */
 use crate::error;
 
-#[derive(Clone, PartialEq, serde::Serialize)]
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "out_json", derive(serde::Serialize))]
 /// Store Variant content
 pub struct Variant {
     /// Sequence name associate with variant
-    #[serde(serialize_with = "crate::serialize_bstr")]
+    #[cfg_attr(feature = "out_json", serde(serialize_with = "crate::serialize_bstr"))]
     pub seqname: Vec<u8>,
 
     /// Position of the variant
     pub position: u64,
 
     /// Reference sequence associate with variant
-    #[serde(serialize_with = "crate::serialize_bstr")]
+    #[cfg_attr(feature = "out_json", serde(serialize_with = "crate::serialize_bstr"))]
     pub ref_seq: Vec<u8>,
 
     /// Alternative sequence associate with variant
-    #[serde(serialize_with = "crate::serialize_bstr")]
+    #[cfg_attr(feature = "out_json", serde(serialize_with = "crate::serialize_bstr"))]
     pub alt_seq: Vec<u8>,
 }
 


### PR DESCRIPTION
Create feature for parquet and json feature.

Build with just `cli` feature (`--no-default-features --features cli`) failed, to avoid this we must create a fake `MythWriter` its possible but necessary for me.

This PR close #8

# Checklist:

- [X] I run `cargo fmt`
- [X] I run `cargo clippy`
- [X] I run `cargo test`
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have check my test covered almost all new code
