### PR TITLE
refactor: FeaturePresence target Effect is now a generic const parameter

### DIFF
--- a/src/effect.rs
+++ b/src/effect.rs
@@ -89,6 +89,7 @@ impl From<&Effect> for Impact {
 		| Effect::StopRetainedVariant // FrameShiftAfterCDS -> Modifer | NonSynonymousStop -> Low | SynonymousStop -> Low
 		| Effect::Duplication // Large, Exon -> High | Gene, Transcript -> Moderate
 		| Effect::Ignore // variant is ignore so…
+		| Effect::Other // it's a fallback so…
 		=> Impact::Other,
 
         }
@@ -97,6 +98,7 @@ impl From<&Effect> for Impact {
 
 /// Effect of variant
 #[derive(Debug, Clone, PartialEq)]
+#[repr(usize)]
 #[cfg_attr(feature = "out_json", derive(serde::Serialize))]
 pub enum Effect {
     /// A sequence variant whereby two genes, on alternate strands have become joined.
@@ -207,6 +209,8 @@ pub enum Effect {
     TranscriptAblation,
     /// A sequence variant located 5' of a gene.
     UpstreamGeneVariant,
+    /// A fallback
+    Other = 54,
 }
 
 impl From<Effect> for Impact {
@@ -275,6 +279,7 @@ impl From<Effect> for Impact {
 		| Effect::StopRetainedVariant // FrameShiftAfterCDS -> Modifer | NonSynonymousStop -> Low | SynonymousStop -> Low
 		| Effect::Duplication // Large, Exon -> High | Gene, Transcript -> Moderate
 		| Effect::Ignore // variant is ignore so…
+		| Effect::Other // it's a fallback so…
 		=> Impact::Other,
 
         }
@@ -342,7 +347,19 @@ impl From<Effect> for Vec<u8> {
             Effect::TfbsAblation => b"TFBS_ablation".to_vec(),
             Effect::TranscriptAblation => b"transcript_ablation".to_vec(),
             Effect::UpstreamGeneVariant => b"upstream_gene_variant".to_vec(),
+            Effect::Other => b"other".to_vec(),
         }
+    }
+}
+
+/// Convert a usize value to Effect it's use for const evaluation
+///
+/// SAFETY: If value is upper than max Effect (aka Effect::Other) value return is Effect::Other
+pub const fn usize2effect(value: usize) -> Effect {
+    if value < Effect::Other as usize {
+        unsafe { std::mem::transmute::<usize, Effect>(value) }
+    } else {
+        Effect::Other
     }
 }
 
@@ -735,5 +752,69 @@ mod tests {
             Vec::<u8>::from(Effect::UpstreamGeneVariant),
             b"upstream_gene_variant".to_vec()
         );
+        assert_eq!(Vec::<u8>::from(Effect::Other), b"other".to_vec());
+    }
+
+    #[test]
+    fn conversion_of_usize2effect() {
+        assert_eq!(usize2effect(0), Effect::BidirectionalGeneFusion);
+        assert_eq!(usize2effect(1), Effect::Chromosome);
+        assert_eq!(usize2effect(2), Effect::ChromosomeNumberVariation);
+        assert_eq!(usize2effect(3), Effect::CodingSequenceVariant);
+        assert_eq!(usize2effect(4), Effect::ConservativeInframeDeletion);
+        assert_eq!(usize2effect(5), Effect::ConservativeInframeInsertion);
+        assert_eq!(usize2effect(6), Effect::ConservedIntergenicVariant);
+        assert_eq!(usize2effect(7), Effect::ConservedIntronVariant);
+        assert_eq!(usize2effect(8), Effect::DisruptiveInframeDeletion);
+        assert_eq!(usize2effect(9), Effect::DisruptiveInframeInsertion);
+        assert_eq!(usize2effect(10), Effect::DownstreamGeneVariant);
+        assert_eq!(usize2effect(11), Effect::Duplication);
+        assert_eq!(usize2effect(12), Effect::ExonLossVariant);
+        assert_eq!(usize2effect(13), Effect::ExonRegion);
+        assert_eq!(usize2effect(14), Effect::FeatureAblation);
+        assert_eq!(usize2effect(15), Effect::FeatureElongation);
+        assert_eq!(usize2effect(16), Effect::FeatureFusion);
+        assert_eq!(usize2effect(17), Effect::FrameshiftVariant);
+        assert_eq!(usize2effect(18), Effect::GeneFusion);
+        assert_eq!(usize2effect(19), Effect::GeneVariant);
+        assert_eq!(usize2effect(20), Effect::Ignore);
+        assert_eq!(usize2effect(21), Effect::InitiatorCodonVariant);
+        assert_eq!(usize2effect(22), Effect::IntergenicRegion);
+        assert_eq!(usize2effect(23), Effect::IntragenicVariant);
+        assert_eq!(usize2effect(24), Effect::IntronVariant);
+        assert_eq!(usize2effect(25), Effect::Inversion);
+        assert_eq!(usize2effect(26), Effect::MiRna);
+        assert_eq!(usize2effect(27), Effect::MissenseVariant);
+        assert_eq!(usize2effect(28), Effect::NonCodingTranscriptExonVariant);
+        assert_eq!(usize2effect(29), Effect::NonCodingTranscriptVariant);
+        assert_eq!(usize2effect(30), Effect::ThreePrimeUtrTruncation);
+        assert_eq!(usize2effect(31), Effect::ThreePrimeUtrVariant);
+        assert_eq!(
+            usize2effect(32),
+            Effect::FivePrimeUtrPrematureStartCodonGainVariant
+        );
+        assert_eq!(usize2effect(33), Effect::FivePrimeUtrTruncation);
+        assert_eq!(usize2effect(34), Effect::FivePrimeUtrVariant);
+        assert_eq!(usize2effect(35), Effect::ProteinProteinContact);
+        assert_eq!(usize2effect(36), Effect::RareAminoAcidVariant);
+        assert_eq!(usize2effect(37), Effect::RearrangedAtDnaLevel);
+        assert_eq!(usize2effect(38), Effect::RegulatoryRegionVariant);
+        assert_eq!(usize2effect(39), Effect::SequenceFeature);
+        assert_eq!(usize2effect(40), Effect::SpliceAcceptorVariant);
+        assert_eq!(usize2effect(41), Effect::SpliceDonorVariant);
+        assert_eq!(usize2effect(42), Effect::SpliceRegionVariant);
+        assert_eq!(usize2effect(43), Effect::StartLost);
+        assert_eq!(usize2effect(44), Effect::StartRetainedVariant);
+        assert_eq!(usize2effect(45), Effect::StopGained);
+        assert_eq!(usize2effect(46), Effect::StopLost);
+        assert_eq!(usize2effect(47), Effect::StopRetainedVariant);
+        assert_eq!(usize2effect(48), Effect::StructuralInteractionVariant);
+        assert_eq!(usize2effect(49), Effect::SynonymousVariant);
+        assert_eq!(usize2effect(50), Effect::TfBindingSiteVariant);
+        assert_eq!(usize2effect(51), Effect::TfbsAblation);
+        assert_eq!(usize2effect(52), Effect::TranscriptAblation);
+        assert_eq!(usize2effect(53), Effect::UpstreamGeneVariant);
+        assert_eq!(usize2effect(54), Effect::Other);
+        assert_eq!(usize2effect(255), Effect::Other);
     }
 }

--- a/src/variant2myth.rs
+++ b/src/variant2myth.rs
@@ -64,22 +64,18 @@ impl<'a> Variant2Myth<'a> {
 
         annotators[(AnnotatorsChoicesRaw::Gene as u8).ilog2() as usize].extend([]);
         annotators[(AnnotatorsChoicesRaw::Feature as u8).ilog2() as usize].extend([
-            Box::new(feature_presence::FeaturePresence::new(
-                b"upstream",
-                effect::Effect::UpstreamGeneVariant,
-            )) as Box<dyn Annotator + Send + Sync>,
-            Box::new(feature_presence::FeaturePresence::new(
-                b"downstream",
-                effect::Effect::DownstreamGeneVariant,
-            )) as Box<dyn Annotator + Send + Sync>,
-            Box::new(feature_presence::FeaturePresence::new(
-                b"5UTR",
-                effect::Effect::FivePrimeUtrVariant,
-            )) as Box<dyn Annotator + Send + Sync>,
-            Box::new(feature_presence::FeaturePresence::new(
-                b"3UTR",
-                effect::Effect::ThreePrimeUtrVariant,
-            )) as Box<dyn Annotator + Send + Sync>,
+            Box::new(feature_presence::FeaturePresence::<
+                { effect::Effect::UpstreamGeneVariant as usize },
+            >::new()) as Box<dyn Annotator + Send + Sync>,
+            Box::new(feature_presence::FeaturePresence::<
+                { effect::Effect::DownstreamGeneVariant as usize },
+            >::new()) as Box<dyn Annotator + Send + Sync>,
+            Box::new(feature_presence::FeaturePresence::<
+                { effect::Effect::FivePrimeUtrVariant as usize },
+            >::new()) as Box<dyn Annotator + Send + Sync>,
+            Box::new(feature_presence::FeaturePresence::<
+                { effect::Effect::ThreePrimeUtrVariant as usize },
+            >::new()) as Box<dyn Annotator + Send + Sync>,
         ]);
         annotators[(AnnotatorsChoicesRaw::Effect as u8).ilog2() as usize].push(Box::new(
             sequence_analysis::SequenceAnalysis::new(translate, sequences),

--- a/src/variant2myth/feature_presence.rs
+++ b/src/variant2myth/feature_presence.rs
@@ -18,6 +18,15 @@ impl<const E: usize> FeaturePresence<E> {
     }
 }
 
+/// Associate an effect to a corresponding feature name
+///
+/// Effect support:
+///   - effect::Effect::UpstreamGeneVariant
+///   - effect::Effect::DownstreamGeneVariant
+///   - effect::Effect::FivePrimeUtrVariant
+///   - effect::Effect::ThreePrimeUtrVariant
+///
+/// If you run this function on any other Effect code panic
 const fn effect2feature_name<const E: usize>() -> &'static [u8] {
     match effect::usize2effect(E) {
         effect::Effect::UpstreamGeneVariant => b"upstream",
@@ -81,6 +90,12 @@ mod tests {
             effect2feature_name::<{ effect::Effect::ThreePrimeUtrVariant as usize }>(),
             b"three_prime_UTR"
         );
+    }
+
+    #[test]
+    #[should_panic]
+    fn convert_effect2feature_name_panic() {
+        effect2feature_name::<{ effect::Effect::BidirectionalGeneFusion as usize }>();
     }
 
     #[test]

--- a/src/variant2myth/feature_presence.rs
+++ b/src/variant2myth/feature_presence.rs
@@ -10,25 +10,35 @@ use crate::effect;
 use crate::variant;
 use crate::variant2myth;
 
-pub struct FeaturePresence {
-    name: &'static [u8],
-    effect: effect::Effect,
-}
+pub struct FeaturePresence<const E: usize> {}
 
-impl FeaturePresence {
-    pub const fn new(name: &'static [u8], effect: effect::Effect) -> Self {
-        Self { name, effect }
+impl<const E: usize> FeaturePresence<E> {
+    pub const fn new() -> Self {
+        Self {}
     }
 }
 
-impl variant2myth::Annotator for FeaturePresence {
+const fn effect2feature_name<const E: usize>() -> &'static [u8] {
+    match effect::usize2effect(E) {
+        effect::Effect::UpstreamGeneVariant => b"upstream",
+        effect::Effect::DownstreamGeneVariant => b"downstream",
+        effect::Effect::FivePrimeUtrVariant => b"five_prime_UTR",
+        effect::Effect::ThreePrimeUtrVariant => b"three_prime_UTR",
+        _ => panic!("Effect isn't support by feature presence."),
+    }
+}
+
+impl<const E: usize> variant2myth::Annotator for FeaturePresence<E> {
     fn annotate(
         &self,
         annotations: &[&annotation::Annotation],
         _variant: &variant::Variant,
     ) -> Vec<effect::Effect> {
-        if annotations.iter().any(|a| a.get_feature() == self.name) {
-            vec![self.effect.clone()]
+        if annotations
+            .iter()
+            .any(|a| a.get_feature() == effect2feature_name::<E>())
+        {
+            vec![effect::usize2effect(E)]
         } else {
             vec![]
         }
@@ -48,15 +58,36 @@ mod tests {
     use crate::error;
     use crate::tests::GFF;
     use crate::variant;
+    use crate::variant2myth::feature_presence::effect2feature_name;
     use crate::variant2myth::Annotator as _;
 
     use super::FeaturePresence;
 
     #[test]
+    fn convert_effect2feature_name() {
+        assert_eq!(
+            effect2feature_name::<{ effect::Effect::UpstreamGeneVariant as usize }>(),
+            b"upstream"
+        );
+        assert_eq!(
+            effect2feature_name::<{ effect::Effect::DownstreamGeneVariant as usize }>(),
+            b"downstream"
+        );
+        assert_eq!(
+            effect2feature_name::<{ effect::Effect::FivePrimeUtrVariant as usize }>(),
+            b"five_prime_UTR"
+        );
+        assert_eq!(
+            effect2feature_name::<{ effect::Effect::ThreePrimeUtrVariant as usize }>(),
+            b"three_prime_UTR"
+        );
+    }
+
+    #[test]
     fn feature_presence() -> error::Result<()> {
         let file = GFF.replace(b"{0}", b"chr1");
 
-        let obj = FeaturePresence::new(b"five_prime_UTR", effect::Effect::FivePrimeUtrVariant);
+        let obj = FeaturePresence::<{ effect::Effect::FivePrimeUtrVariant as usize }>::new();
         let annotation = annotation::Annotation::from_byte_record(&csv::ByteRecord::from(
             String::from_utf8(file[292..374].to_vec())
                 .unwrap()
@@ -80,7 +111,7 @@ mod tests {
     fn feature_absence() -> error::Result<()> {
         let file = GFF.replace(b"{0}", b"chr1");
 
-        let obj = FeaturePresence::new(b"three_prime_UTR", effect::Effect::ThreePrimeUtrVariant);
+        let obj = FeaturePresence::<{ effect::Effect::ThreePrimeUtrVariant as usize }>::new();
         let annotation = annotation::Annotation::from_byte_record(&csv::ByteRecord::from(
             String::from_utf8(file[292..374].to_vec())
                 .unwrap()


### PR DESCRIPTION
Benefit:
- Replace pair of argument by one
- Fix link between Effect and feature name
- ~Improve Run time~ (no)

Drawback:
- Fix link between Effect and feature name
- Force effect to have a repr(primitive type)
- Use a const unsafe function for conversion between Effect and primitive type
- Add an Effect::Other to fallback for this const unsafe function
- If you want add a new FeaturePresence you must edit FeaturePresence code

# Checklist:

- [X] I run `cargo fmt`
- [X] I run `cargo clippy`
- [X] I run `cargo test`
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have check my test covered almost all new code
